### PR TITLE
fix: composite PK equals/hashCode overrides

### DIFF
--- a/src/main/java/com/example/echo_api/persistence/model/block/BlockPK.java
+++ b/src/main/java/com/example/echo_api/persistence/model/block/BlockPK.java
@@ -1,6 +1,8 @@
 package com.example.echo_api.persistence.model.block;
 
+import java.util.Objects;
 import java.util.UUID;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,5 +16,25 @@ public class BlockPK {
     private UUID blockerId;
 
     private UUID blockedId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null)
+            return false;
+        if (!(o instanceof BlockPK))
+            return false;
+
+        BlockPK that = (BlockPK) o;
+
+        return this.blockerId.equals(that.blockerId) &&
+            this.blockedId.equals(that.blockedId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(blockerId, blockedId);
+    }
 
 }

--- a/src/main/java/com/example/echo_api/persistence/model/follow/FollowPK.java
+++ b/src/main/java/com/example/echo_api/persistence/model/follow/FollowPK.java
@@ -1,6 +1,8 @@
 package com.example.echo_api.persistence.model.follow;
 
+import java.util.Objects;
 import java.util.UUID;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,5 +16,25 @@ public class FollowPK {
     private UUID followerId;
 
     private UUID followedId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null)
+            return false;
+        if (!(o instanceof FollowPK))
+            return false;
+
+        FollowPK that = (FollowPK) o;
+
+        return this.followerId.equals(that.followerId) &&
+            this.followedId.equals(that.followedId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(followerId, followedId);
+    }
 
 }

--- a/src/main/java/com/example/echo_api/persistence/model/post/like/PostLikePK.java
+++ b/src/main/java/com/example/echo_api/persistence/model/post/like/PostLikePK.java
@@ -1,5 +1,6 @@
 package com.example.echo_api.persistence.model.post.like;
 
+import java.util.Objects;
 import java.util.UUID;
 
 import lombok.Getter;
@@ -15,5 +16,25 @@ public class PostLikePK {
     private UUID postId;
 
     private UUID authorId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null)
+            return false;
+        if (!(o instanceof PostLikePK))
+            return false;
+
+        PostLikePK that = (PostLikePK) o;
+
+        return this.postId.equals(that.postId) &&
+            this.authorId.equals(that.authorId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(postId, authorId);
+    }
 
 }


### PR DESCRIPTION
## Purpose
PR introduces a small fix to multiple composite primary key classes by implementing `equals` and `hashCode` method overrides that were previously missing.

## Changelog
### Persistence
- Add `equals` and `hashCode` methods to `BlockPK`
- Add `equals` and `hashCode` methods to `FollowPK`
- Add `equals` and `hashCode` methods to `PostLikePK`