### PR TITLE
ci: update dev PR title workflow

### DIFF
--- a/.github/workflows/dev-pr-title.yml
+++ b/.github/workflows/dev-pr-title.yml
@@ -17,14 +17,14 @@ jobs:
               run: |
 
                   # Pattern
-                  PATTERN="^(feat|fix|docs|style|refactor|perf|test|chore|ci|build)([!])?:"
+                  PATTERN="^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)([!])?:"
 
                   # Check if the PR title matches the expected pattern
                   if [[ ! '${{ github.event.pull_request.title }}' =~ $PATTERN ]]; then
                   echo "❌ PR title must follow the Conventional Commits format!"
                   echo ""
                   echo "Expected title format:"
-                  echo "<type>[optional scope]: <description>"
+                  echo "[optional scope] <type>: <description>"
                   echo ""
                   echo "Valid types: feat, fix, docs, style, refactor, perf, test, chore, ci, build"
                   echo "For breaking changes, use: <type>!: <description>"


### PR DESCRIPTION
## Purpose
PR introduces an update to the dev PR title workflow by adding `revert` as a valid PR type and by moving the `[optional scope]` tag to the beginning of the PR title expected format.

The optional scope should be used to indicate which repository is being touched in the PR, e.g., `[api] feat: some endpoint`. This strays from the recommended Conventional Commits format, but reads better to my eyes.


## Changelog
### GH workflows
- Refactored `dev-pr-title-check.yml` REGEX & expected title format, renamed file to `dev-pr-title.yml`
