### PR TITLE
ci: fix dev PR title regex

### DIFF
--- a/.github/workflows/dev-pr-title.yml
+++ b/.github/workflows/dev-pr-title.yml
@@ -20,7 +20,7 @@ jobs:
                   set +H
 
                   # Pattern
-                  PATTERN="^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(!)?:"
+                  PATTERN="^(\[(\w|\-)+\] )?(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(!)?:"
 
                   # Check if the PR title matches the expected pattern
                   if [[ ! '${{ github.event.pull_request.title }}' =~ $PATTERN ]]; then

--- a/.github/workflows/dev-pr-title.yml
+++ b/.github/workflows/dev-pr-title.yml
@@ -26,12 +26,12 @@ jobs:
                   echo "Expected title format:"
                   echo "[optional scope] <type>: <description>"
                   echo ""
-                  echo "Valid types: feat, fix, docs, style, refactor, perf, test, chore, ci, build"
+                  echo "Valid types: feat, fix, docs, style, refactor, perf, test, chore, ci, build, revert"
                   echo "For breaking changes, use: <type>!: <description>"
                   echo ""
                   echo "See: https://www.conventionalcommits.org/en/v1.0.0/ for more details."
                   exit 1
                   fi
 
-                  # Print success message if the title is valid (optional)
+                  # Print success message if the title is valid
                   echo "✅ PR title follows Conventional Commits format."

--- a/.github/workflows/dev-pr-title.yml
+++ b/.github/workflows/dev-pr-title.yml
@@ -16,8 +16,11 @@ jobs:
             - name: Validate PR title
               run: |
 
+                  # Disable history expansion to allow '!' in title
+                  set +H
+
                   # Pattern
-                  PATTERN="^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)([!])?:"
+                  PATTERN="^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(!)?:"
 
                   # Check if the PR title matches the expected pattern
                   if [[ ! '${{ github.event.pull_request.title }}' =~ $PATTERN ]]; then


### PR DESCRIPTION
## Purpose
PR introduces a fix to `Validate Dev PR Title` workflow

## Changelog
### Workflows
- The echoed list of allowed PR types now correctly includes `revert` when the job fails
- A PR title can now contain the `!` character without causing unintended behaviour
- Fixed PR title regex to correctly account for `[optional scope]` tag