### PR TITLE
[api] chore: remove redundant interface access modifiers

### DIFF
--- a/api/src/main/java/com/example/echo_api/modules/post/service/PostInteractionService.java
+++ b/api/src/main/java/com/example/echo_api/modules/post/service/PostInteractionService.java
@@ -13,7 +13,7 @@ public interface PostInteractionService {
      * @throws ApplicationException if no post with the given id exists
      * @throws ApplicationException if already liked the post
      */
-    public void like(UUID id);
+    void like(UUID id);
 
     /**
      * Unlike a post by {@code id}.
@@ -23,6 +23,6 @@ public interface PostInteractionService {
      * 
      * @param id the id of the post to unlike
      */
-    public void unlike(UUID id);
+    void unlike(UUID id);
 
 }

--- a/api/src/main/java/com/example/echo_api/modules/post/service/PostManagementService.java
+++ b/api/src/main/java/com/example/echo_api/modules/post/service/PostManagementService.java
@@ -15,7 +15,7 @@ public interface PostManagementService {
      * @throws ApplicationException if the parent id is present and no post with the
      *                              given id exists
      */
-    public void create(CreatePostDTO request);
+    void create(CreatePostDTO request);
 
     /**
      * Delete a {@link Post} via {@code id} for the authenticated user.
@@ -24,6 +24,6 @@ public interface PostManagementService {
      * @throws ApplicationException if the authenticated user is not the author if
      *                              the post given by id if it exists
      */
-    public void delete(UUID id);
+    void delete(UUID id);
 
 }

--- a/api/src/main/java/com/example/echo_api/modules/post/service/PostViewService.java
+++ b/api/src/main/java/com/example/echo_api/modules/post/service/PostViewService.java
@@ -17,7 +17,7 @@ public interface PostViewService {
      * @return a {@link PostDTO} resembling the queried post
      * @throws ApplicationException if no post with the given id exists
      */
-    public PostDTO getPostById(UUID id);
+    PostDTO getPostById(UUID id);
 
     /**
      * Fetch a {@link PageDTO} of {@link PostDTO} for the posts that are in reply to
@@ -28,7 +28,7 @@ public interface PostViewService {
      * @return a {@link PageDTO} of {@link PostDTO} for matches, otherwise empty
      * @throws ApplicationException if no post with the given id exists
      */
-    public PageDTO<PostDTO> getRepliesByPostId(UUID id, Pageable page); // TODO: refactor to getConversationByPostId
+    PageDTO<PostDTO> getRepliesByPostId(UUID id, Pageable page); // TODO: refactor to getConversationByPostId
 
     /**
      * Fetch a {@link PageDTO} of {@link PostDTO} for posts from the user with the
@@ -39,7 +39,7 @@ public interface PostViewService {
      * @return a {@link PageDTO} of {@link PostDTO} for matches, otherwise empty
      * @throws ApplicationException if no profile with the given id exists
      */
-    public PageDTO<PostDTO> getPostsByAuthorId(UUID id, Pageable page);
+    PageDTO<PostDTO> getPostsByAuthorId(UUID id, Pageable page);
 
     /**
      * Fetch a {@link PageDTO} of {@link PostDTO} for posts from the user with the
@@ -50,7 +50,7 @@ public interface PostViewService {
      * @return a {@link PageDTO} of {@link PostDTO} for matches, otherwise empty
      * @throws ApplicationException if no profile with the given id exists
      */
-    public PageDTO<PostDTO> getRepliesByAuthorId(UUID id, Pageable page);
+    PageDTO<PostDTO> getRepliesByAuthorId(UUID id, Pageable page);
 
     /**
      * Fetch a {@link PageDTO} of {@link PostDTO} for posts liked by the user with
@@ -61,7 +61,7 @@ public interface PostViewService {
      * @return a {@link PageDTO} of {@link PostDTO} for matches, otherwise empty
      * @throws ApplicationException if no profile with the given id exists
      */
-    public PageDTO<PostDTO> getLikesByAuthorId(UUID id, Pageable page);
+    PageDTO<PostDTO> getLikesByAuthorId(UUID id, Pageable page);
 
     /**
      * Fetch a {@link PageDTO} of {@link PostDTO} for posts that contain a mention
@@ -72,7 +72,7 @@ public interface PostViewService {
      * @return a {@link PageDTO} of {@link PostDTO} for matches, otherwise empty
      * @throws ApplicationException if no profile with the given id exists
      */
-    public PageDTO<PostDTO> getMentionsOfProfileId(UUID id, Pageable page);
+    PageDTO<PostDTO> getMentionsOfProfileId(UUID id, Pageable page);
 
     /**
      * Fetch a {@link PageDTO} of {@link PostDTO} for posts from the authenticated
@@ -81,7 +81,7 @@ public interface PostViewService {
      * @param page the {@link Pageable} containing the pagination parameters
      * @return a {@link PageDTO} of {@link PostDTO} for matches, otherwise empty
      */
-    public PageDTO<PostDTO> getHomepagePosts(Pageable page);
+    PageDTO<PostDTO> getHomepagePosts(Pageable page);
 
     /**
      * Fetch a {@link PageDTO} of {@link PostDTO} for posts from all users.
@@ -89,6 +89,6 @@ public interface PostViewService {
      * @param page the {@link Pageable} containing the pagination parameters
      * @return a {@link PageDTO} of {@link PostDTO} for matches, otherwise empty
      */
-    public PageDTO<PostDTO> getDiscoverPosts(Pageable page);
+    PageDTO<PostDTO> getDiscoverPosts(Pageable page);
 
 }

--- a/api/src/main/java/com/example/echo_api/modules/profile/service/ProfileInteractionService.java
+++ b/api/src/main/java/com/example/echo_api/modules/profile/service/ProfileInteractionService.java
@@ -14,7 +14,7 @@ public interface ProfileInteractionService {
      * @throws ApplicationException if attempting to follow self profile
      * @throws ApplicationException if already following the profile
      */
-    public void follow(UUID id);
+    void follow(UUID id);
 
     /**
      * Unfollows a profile by {@code id}.
@@ -24,6 +24,6 @@ public interface ProfileInteractionService {
      * 
      * @param id the profile id
      */
-    public void unfollow(UUID id);
+    void unfollow(UUID id);
 
 }

--- a/api/src/main/java/com/example/echo_api/modules/profile/service/ProfileManagementService.java
+++ b/api/src/main/java/com/example/echo_api/modules/profile/service/ProfileManagementService.java
@@ -12,6 +12,6 @@ public interface ProfileManagementService {
      * 
      * @param request the request DTO containing the updated profile information
      */
-    public void updateProfile(UpdateProfileDTO request);
+    void updateProfile(UpdateProfileDTO request);
 
 }

--- a/api/src/main/java/com/example/echo_api/modules/profile/service/ProfileViewService.java
+++ b/api/src/main/java/com/example/echo_api/modules/profile/service/ProfileViewService.java
@@ -16,7 +16,7 @@ public interface ProfileViewService {
      * 
      * @return a {@link ProfileDTO} resembling the users profile
      */
-    public ProfileDTO getMe();
+    ProfileDTO getMe();
 
     /**
      * Fetch a {@link ProfileDTO} by {@code id}.
@@ -25,7 +25,7 @@ public interface ProfileViewService {
      * @return a {@link ProfileDTO} resembling the queried profile
      * @throws ApplicationException if no profile with the given id exists
      */
-    public ProfileDTO getById(UUID id);
+    ProfileDTO getById(UUID id);
 
     /**
      * Fetch a {@link ProfileDTO} by {@code username}.
@@ -34,7 +34,7 @@ public interface ProfileViewService {
      * @return a {@link ProfileDTO} resembling the queried profile
      * @throws ApplicationException if no profile with the given username exists
      */
-    public ProfileDTO getByUsername(String username);
+    ProfileDTO getByUsername(String username);
 
     /**
      * Fetch a {@link PageDTO} of {@link SimplifiedProfileDTO} for the followers
@@ -46,7 +46,7 @@ public interface ProfileViewService {
      *         otherwise empty
      * @throws ApplicationException if no profile with the given id exists
      */
-    public PageDTO<SimplifiedProfileDTO> getFollowers(UUID id, Pageable page);
+    PageDTO<SimplifiedProfileDTO> getFollowers(UUID id, Pageable page);
 
     /**
      * Fetch a {@link PageDTO} of {@link SimplifiedProfileDTO} for the following
@@ -58,6 +58,6 @@ public interface ProfileViewService {
      *         otherwise empty
      * @throws ApplicationException if no profile with the given id exists
      */
-    public PageDTO<SimplifiedProfileDTO> getFollowing(UUID id, Pageable page);
+    PageDTO<SimplifiedProfileDTO> getFollowing(UUID id, Pageable page);
 
 }

--- a/api/src/main/java/com/example/echo_api/modules/user/service/UserService.java
+++ b/api/src/main/java/com/example/echo_api/modules/user/service/UserService.java
@@ -26,7 +26,7 @@ public interface UserService {
      * @throws IllegalArgumentException if {@code externalId} or {@code username} is
      *                                  null
      */
-    public User upsertFromExternalSource(String externalId, String username, String imageUrl);
+    User upsertFromExternalSource(String externalId, String username, String imageUrl);
 
     /**
      * Deletes a local {@link User} and its associated data based on the external
@@ -42,6 +42,6 @@ public interface UserService {
      * @param externalId the unique identifier from the IDP
      * @return the number of affected records (0 or 1)
      */
-    public int deleteFromExternalSource(String externalId);
+    int deleteFromExternalSource(String externalId);
 
 }

--- a/api/src/main/java/com/example/echo_api/shared/service/SessionService.java
+++ b/api/src/main/java/com/example/echo_api/shared/service/SessionService.java
@@ -16,7 +16,7 @@ public interface SessionService {
      * 
      * @return The UUID of the authenticated user
      */
-    public UUID getAuthenticatedUserId();
+    UUID getAuthenticatedUserId();
 
     /**
      * Retrieve the authenticated user Clerk ID from the authenticated Clerk token.
@@ -27,7 +27,7 @@ public interface SessionService {
      * 
      * @return The Clerk ID of the authenticated user
      */
-    public String getAuthenticatedUserClerkId();
+    String getAuthenticatedUserClerkId();
 
     /**
      * Retrieve the authenticated user onboarding status from the authenticated
@@ -39,6 +39,6 @@ public interface SessionService {
      * 
      * @return A boolean representing the {@code onboarded} claim
      */
-    public boolean isAuthenticatedUserOnboarded();
+    boolean isAuthenticatedUserOnboarded();
 
 }


### PR DESCRIPTION
Interface methods are `public abstract` by default. 